### PR TITLE
build.gradleにMySQLドライバーとMyBatisを追加

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,12 @@ dependencies {
 	// 便利機能、ユーティリティ(Apache Commons Lang)
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 
+	// MySQLドライバー
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// MyBatis
+	implementation 'org.springframework.boot:spring-boot-starter:3.5.5'
+
 	providedRuntime 'org.springframework.boot:spring-boot-starter-tomcat'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
## 実装内容
- MyBatisを使ったSQL マッピングの実装(build.gradleにMySQLドライバーとMyBatisを追加のみ)