### PR TITLE
受講生情報更新処理の実装

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -51,10 +51,16 @@ public class StudentController {
   }
 
   @GetMapping("/updateStudent")
-  public String updateStudent(@RequestParam int id, Model model) {
+  public String updateStudent(@RequestParam Integer id, Model model) {
     StudentDetail studentDetail = service.searchStudent(id);
-    model.addAttribute("StudentDetail", studentDetail);
+    model.addAttribute("studentDetail", studentDetail);
     return "updateStudent";
+  }
+
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail) {
+    service.updateStudent(studentDetail);
+    return "redirect:/studentsList";
   }
 
   @PostMapping("/registerStudent")

--- a/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
+++ b/src/main/java/raisetech/student/management/controller/converter/StudentConverter.java
@@ -2,6 +2,7 @@ package raisetech.student.management.controller.converter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 import raisetech.student.management.data.Student;
@@ -19,7 +20,7 @@ public class StudentConverter {
       studentDetail.setStudent(student);
 
       List<StudentCourse> convertStudentCourses = studentCourses.stream()
-          .filter(studentCourse -> student.getId().equals(studentCourse.getStudentId()))
+          .filter(studentCourse -> Objects.equals(student.getId(), studentCourse.getStudentId()))
           .collect(Collectors.toList());
 
       studentDetail.setStudentCourse(convertStudentCourses);

--- a/src/main/java/raisetech/student/management/data/Student.java
+++ b/src/main/java/raisetech/student/management/data/Student.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class Student {
 
-  private int id;
+  private Integer id;
   private String name;
   private String kanaName;
   private String nickname;

--- a/src/main/java/raisetech/student/management/data/StudentCourse.java
+++ b/src/main/java/raisetech/student/management/data/StudentCourse.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class StudentCourse {
 
-  private int id;
+  private Integer id;
   private String studentId;
   private String courseName;
   private LocalDateTime courseStartAt;

--- a/src/main/java/raisetech/student/management/repository/StudentRepository.java
+++ b/src/main/java/raisetech/student/management/repository/StudentRepository.java
@@ -46,13 +46,15 @@ public interface StudentRepository {
   List<StudentCourse> searchStudentCourses();
 
   @Insert(
-      "INSERT INTO students(name, kana_name, nickname, email, area, age, gender, remark, is_deleted) "
+      "INSERT INTO students "
+          + "(name, kana_name, nickname, email, area, age, gender, remark, is_deleted) "
           + "VALUES(#{name}, #{kanaName}, #{nickname}, #{email}, #{area}, #{age}, #{gender}, #{remark}, false)")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void registerStudent(Student student);
 
   @Insert(
-      "INSERT INTO students_courses(student_id, course_name, course_start_at, course_end_at) "
+      "INSERT INTO students_courses "
+          + "(student_id, course_name, course_start_at, course_end_at) "
           + "VALUES(#{studentId}, #{courseName}, #{courseStartAt}, #{courseEndAt})")
   @Options(useGeneratedKeys = true, keyProperty = "id")
   void registerStudentCourse(StudentCourse studentCourse);
@@ -70,4 +72,32 @@ public interface StudentRepository {
           + "WHERE id = #{id}"
   )
   void updateStudent(Student student);
+
+  /**
+   * IDで受講生を1件検索する
+   *
+   * @param id 検索する受講生のID
+   * @return 見つかった受講生(見つからない場合はnull)
+   */
+  @Select("SELECT * FROM students WHERE id = #{id}")
+  Student searchStudent(Integer id);
+
+  /**
+   * 指定された受講生IDのコース情報を取得する
+   *
+   * @param studentId 受講生のID
+   * @return その受講生のコース情報リスト
+   */
+  @Select("SELECT * FROM students_courses WHERE student_id = #{studentId}")
+  List<StudentCourse> searchStudentCoursesByStudentId(Integer studentId);
+
+  @Update(
+      "UPDATE students_courses "
+          + "SET course_name = #{courseName}, "
+          + "course_start_at = #{courseStartAt}, "
+          + "course_end_at = #{courseEndAt} "
+          + "WHERE student_id = #{studentId}"
+  )
+  void updateStudentCourse(StudentCourse studentCourse);
 }
+

--- a/src/main/java/raisetech/student/management/service/StudentService.java
+++ b/src/main/java/raisetech/student/management/service/StudentService.java
@@ -28,14 +28,66 @@ public class StudentService {
     return repository.searchStudentCourses();
   }
 
+  // 複数のデータベース操作を1つのトランザクションとしてまとめるアノテーション
   @Transactional
   public void registerStudent(StudentDetail studentDetail) {
+    // 受講生の基本情報を登録(students テーブル)
     repository.registerStudent(studentDetail.getStudent());
+    // studentDetail.getStudent()
+    //    ↓
+    // Student { id: null, name: "山田太郎", age: 25, ... }
+    //    ↓
+    // repository.registerStudent(student)
+    //    ↓
+    // INSERT INTO students(...) VALUES(...)
+    //    ↓
+    // データベースが自動でIDを生成(例: 123)
+    //    ↓
+    // @Options(useGeneratedKeys = true) により
+    // studentオブジェクトのidに123が自動セット
+    //    ↓
+    // Student { id: 123, name: "山田太郎", age: 25, ... }
+    // 登録時に自動生成されたIDを取得
     for (StudentCourse studentCourse : studentDetail.getStudentCourse()) {
-      studentCourse.setStudentId(studentDetail.getStudent().getId()); // String -> id の影響か？
+      // 受講生IDをセット
+      studentCourse.setStudentId(
+          String.valueOf(studentDetail.getStudent().getId()));
+      // 開始日・終了日をセット
       studentCourse.setCourseStartAt(LocalDateTime.now());
       studentCourse.setCourseEndAt(LocalDateTime.now().plusYears(1));
       repository.registerStudentCourse(studentCourse);
+    }
+  }
+
+  public StudentDetail searchStudent(int id) {
+    // ①リポジトリで受講生を検索
+    Student student = repository.searchStudent(id);
+    // どちらでもOKだが、idの方がシンプル
+    //    repository.searchStudentCoursesByStudentId(id);  // ← こっちでOK
+    //    repository.searchStudentCoursesByStudentId(student.getId());  // これも同じ
+    // ②リポジトリでその人のコースを検索
+    List<StudentCourse> studentCourses = repository.searchStudentCoursesByStudentId(id);
+    // ③StudentDetailに詰めて返す
+    StudentDetail studentDetail = new StudentDetail();
+    // ④ 受講生情報をセット
+    studentDetail.setStudent(student);
+    // ⑤ コース情報をセット
+    studentDetail.setStudentCourse(studentCourses);
+    // ⑥ 完成したStudentDetailを返す
+    return studentDetail;
+  }
+
+  @Transactional
+  public void updateStudent(StudentDetail studentDetail) {
+    // ①受講生情報を更新
+    repository.updateStudent(studentDetail.getStudent());
+    // ②コース情報を更新(forループで全コースを更新)
+    for (StudentCourse studentCourse : studentDetail.getStudentCourse()) {
+      studentCourse.setStudentId(
+          String.valueOf(studentDetail.getStudent().getId()));
+      studentCourse.setCourseStartAt(LocalDateTime.now());
+      studentCourse.setCourseEndAt(LocalDateTime.now().plusYears(1));
+      repository.updateStudentCourse(studentCourse);
     }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,14 @@
 spring.application.name=StudentManagement
-# データベース設定
+# ????????
 spring.datasource.url=jdbc:mysql://localhost:3306/student
 spring.datasource.username=root
 spring.datasource.password=
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-# MyBatis設定
+# MyBatis??
 #mybatis.mapper-locations=classpath:mappers/*.xml
 mybatis.configuration.map-underscore-to-camel-case=true
 #mybatis.configuration.default-fetch-size=100
 #mybatis.configuration.default-statement-timeout=30
-# ログ設定
+# ????
 #logging.level.com.example.mapper=DEBUG
 #logging.level.org.mybatis=DEBUG

--- a/src/main/resources/flow.txt
+++ b/src/main/resources/flow.txt
@@ -1,0 +1,56 @@
+1. タスク5: リポジトリ(SQL文)
+     ↓ (これができたら次へ)
+2. タスク4: サービス
+     ↓
+3. タスク8: リポジトリの更新SQL
+     ↓
+4. タスク7: サービスの更新メソッド
+     ↓
+5. タスク3: コントローラーの表示メソッド
+     ↓
+6. タスク6: コントローラーの更新メソッド
+     ↓
+7. タスク1: HTML作成
+     ↓
+8. タスク2: 一覧画面にリンク追加
+
+【Service層】
+service.searchStudent(123) の中で:
+
+① repository.searchStudent(123) を呼び出し
+    ↓
+【Repository層】
+@Select("SELECT * FROM students WHERE id = 123")
+    ↓
+【Database】
+SELECT * FROM students WHERE id = 123;
+    ↓
+結果: { id: 123, name: "山田太郎", age: 25, ... }
+    ↓
+【Repository層】
+Studentオブジェクトに変換
+    ↓
+【Service層】
+Student student = ... で受け取る
+
+---
+
+② repository.searchStudentCoursesByStudentId(123) を呼び出し
+    ↓
+【Repository層】
+@Select("SELECT * FROM students_courses WHERE student_id = 123")
+    ↓
+【Database】
+SELECT * FROM students_courses WHERE student_id = 123;
+    ↓
+結果:
+[
+  { id: 1, student_id: 123, course_name: "Java", ... },
+  { id: 2, student_id: 123, course_name: "AWS", ... }
+]
+    ↓
+【Repository層】
+List<StudentCourse>に変換
+    ↓
+【Service層】
+List<StudentCourse> studentCourses = ... で受け取る

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -23,7 +23,8 @@
   <tbody>
   <tr th:each="studentDetail : ${studentList}">
     <td th:text="${studentDetail.student.id}">1</td>
-    <td><a th:href="@{/updateStudent/(name=*{name})}" th:text="${studentDetail.student.name}">Aika</a></td>
+    <td><a th:href="@{/updateStudent(id=${studentDetail.student.id})}"
+           th:text="${studentDetail.student.name}">Aika</a></td> <!-- Controller側で@RequestParam int idとして受け取っているため、パラメータ名はidである必要がある-->
     <td th:text="${studentDetail.student.kanaName}">あいか</td>
     <td th:text="${studentDetail.student.nickname}">あいかちゃん</td>
     <td th:text="${studentDetail.student.email}">aika@gmail.com</td>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -7,9 +7,10 @@
 <body>
 <h1>受講生更新</h1>
 <form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <input type="hidden" th:field="*{student.id}">
   <div>
     <label for="name">名前:</label>
-    <input type="hidden" id="name" th:field="*{student.name}" required>
+    <input type="text" id="name" th:field="*{student.name}" required>
   </div>
   <div>
     <label for="kanaName">カナ名:</label>
@@ -17,34 +18,34 @@
   </div>
   <div>
     <label for="nickname">ニックネーム:</label>
-    <input type="hidden" id="nickname" th:field="*{student.nickname}">
+    <input type="text" id="nickname" th:field="*{student.nickname}">
   </div>
   <div>
     <label for="email">メールアドレス:</label>
-    <input type="hidden" id="email" th:field="*{student.email}" required>
+    <input type="text" id="email" th:field="*{student.email}" required>
   </div>
   <div>
     <label for="area">地域:</label>
-    <input type="hidden" id="area" th:field="*{student.area}">
+    <input type="text" id="area" th:field="*{student.area}">
   </div>
   <div>
     <label for="age">年齢:</label>
-    <input type="hidden" id="age" th:field="*{student.age}">
+    <input type="text" id="age" th:field="*{student.age}">
   </div>
   <div>
     <label for="gender">性別:</label>
-    <input type="hidden" id="gender" th:field="*{student.gender}">
+    <input type="text" id="gender" th:field="*{student.gender}">
   </div>
   <div>
     <label for="remark">備考:</label>
-    <input type="hidden" id="remark" th:field="*{student.remark}">
+    <input type="text" id="remark" th:field="*{student.remark}">
   </div>
   <div th:each="course, stat : *{studentCourse}">
     <label for="courseName" th:for="studentCourse[__${stat.index}__].courseName">受講コース名:</label>
-    <input type="hidden" id="courseName" th:id="studentCourse.__${stat.index}__.courseName" th:field="*{studentCourse[__${stat.index}__].courseName}">
+    <input type="text" id="courseName" th:id="studentCourse.__${stat.index}__.courseName" th:field="*{studentCourse[__${stat.index}__].courseName}">
   </div>
   <div>
-    <button type="submit">登録</button>
+    <button type="submit">更新</button>
   </div>
 </form>
 </body>


### PR DESCRIPTION
## 実装内容
- 受講生登録情報の更新をするために、新たにupdateStudent.htmlを追加しました。
- コントローラーに更新画面表示処理を追加しました
- データ層のidの型をIntegerに変更しました
- リポジトリ層に情報更新のためのSQL文を追加しました
- サービス層に情報更新操作処理を追加しました

## 動作確認
### 1. 更新画面
<img width="684" height="379" alt="スクリーンショット 2025-10-05 21 39 41" src="https://github.com/user-attachments/assets/45b738e0-9c20-4ecf-8f08-6150c370a699" />


### 2. 受講生情報更新成功時
<img width="723" height="407" alt="スクリーンショット 2025-10-05 21 39 21" src="https://github.com/user-attachments/assets/1f887239-9eea-463d-9c50-3c01cf5b34a3" />

## コードの問題
- 同じ人が2つコースを受講している場合、同じコースが2つ登録されている問題(片方だけ変更不可)
- 元々1つしか受講していない場合新たにもう一つ登録できない

## 学んだこと
- @Options(useGeneratedKeys = true)の使い分けについて、INSERT時のみ必要で、UPDATE時は不要であること
- INSERT文とUPDATE文の構文の違い
- 更新処理では「特定の1人を編集する」という明確な目的があるため、単一検索が適していること
- SQL構文エラーのデバッグ(エラーメッセージのnear '...'の部分を見ることで、どこに問題があるかを特定できること)